### PR TITLE
Reimplement Body.OnCollision & Body.OnSeparation

### DIFF
--- a/Physics2D/Dynamics/Body.cs
+++ b/Physics2D/Dynamics/Body.cs
@@ -1189,40 +1189,18 @@ namespace tainicom.Aether.Physics2D.Dynamics
             _xf.p = _sweep.C - Complex.Multiply(ref _sweep.LocalCenter, ref _xf.q);
         }
 
+        internal OnCollisionEventHandler onCollisionEventHandler;
         public event OnCollisionEventHandler OnCollision
         {
-            add
-            {
-                for (int i = 0; i < FixtureList.Count; i++)
-                {
-                    FixtureList[i].OnCollision += value;
-                }
-            }
-            remove
-            {
-                for (int i = 0; i < FixtureList.Count; i++)
-                {
-                    FixtureList[i].OnCollision -= value;
-                }
-            }
+            add { onCollisionEventHandler += value; }
+            remove { onCollisionEventHandler -= value; }
         }
 
+        internal OnSeparationEventHandler onSeparationEventHandler;
         public event OnSeparationEventHandler OnSeparation
         {
-            add
-            {
-                for (int i = 0; i < FixtureList.Count; i++)
-                {
-                    FixtureList[i].OnSeparation += value;
-                }
-            }
-            remove
-            {
-                for (int i = 0; i < FixtureList.Count; i++)
-                {
-                    FixtureList[i].OnSeparation -= value;
-                }
-            }
+            add { onSeparationEventHandler += value; }
+            remove { onSeparationEventHandler -= value; }
         }
 
         public void IgnoreCollisionWith(Body other)

--- a/Physics2D/Dynamics/ContactManager.cs
+++ b/Physics2D/Dynamics/ContactManager.cs
@@ -240,6 +240,15 @@ namespace tainicom.Aether.Physics2D.Dynamics
                 if (fixtureB != null && fixtureB.OnSeparation != null)
                     fixtureB.OnSeparation(fixtureB, fixtureA, contact);
 
+                //Report the separation to both bodies:
+                if (fixtureA != null && fixtureA.Body != null && fixtureA.Body.onSeparationEventHandler != null)
+                    fixtureA.Body.onSeparationEventHandler(fixtureA, fixtureB, contact);
+
+                //Reverse the order of the reported fixtures. The first fixture is always the one that the
+                //user subscribed to.
+                if (fixtureB != null && fixtureB.Body != null && fixtureB.Body.onSeparationEventHandler != null)
+                    fixtureB.Body.onSeparationEventHandler(fixtureB, fixtureA, contact);
+
                 if (EndContact != null)
                     EndContact(contact);
             }

--- a/Physics2D/Dynamics/ContactManager.cs
+++ b/Physics2D/Dynamics/ContactManager.cs
@@ -233,12 +233,12 @@ namespace tainicom.Aether.Physics2D.Dynamics
             {
                 //Report the separation to both participants:
                 if (fixtureA != null && fixtureA.OnSeparation != null)
-                    fixtureA.OnSeparation(fixtureA, fixtureB);
+                    fixtureA.OnSeparation(fixtureA, fixtureB, contact);
 
                 //Reverse the order of the reported fixtures. The first fixture is always the one that the
                 //user subscribed to.
                 if (fixtureB != null && fixtureB.OnSeparation != null)
-                    fixtureB.OnSeparation(fixtureB, fixtureA);
+                    fixtureB.OnSeparation(fixtureB, fixtureA, contact);
 
                 if (EndContact != null)
                     EndContact(contact);

--- a/Physics2D/Dynamics/Contacts/Contact.cs
+++ b/Physics2D/Dynamics/Contacts/Contact.cs
@@ -315,45 +315,25 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
             {
                 if (touching)
                 {
-                    if (Settings.AllCollisionCallbacksAgree)
-                    {
-                        bool enabledA = true, enabledB = true;
+                    bool enabledA = true, enabledB = true;
 
-                        // Report the collision to both participants. Track which ones returned true so we can
-                        // later call OnSeparation if the contact is disabled for a different reason.
-                        if (FixtureA.OnCollision != null)
-                            foreach (OnCollisionEventHandler handler in FixtureA.OnCollision.GetInvocationList())
-                                enabledA = handler(FixtureA, FixtureB, this) && enabledA;
+                    // Report the collision to both participants. Track which ones returned true so we can
+                    // later call OnSeparation if the contact is disabled for a different reason.
+                    if (FixtureA.OnCollision != null)
+                        foreach (OnCollisionEventHandler handler in FixtureA.OnCollision.GetInvocationList())
+                            enabledA = handler(FixtureA, FixtureB, this) && enabledA;
 
-                        // Reverse the order of the reported fixtures. The first fixture is always the one that the
-                        // user subscribed to.
-                        if (FixtureB.OnCollision != null)
-                            foreach (OnCollisionEventHandler handler in FixtureB.OnCollision.GetInvocationList())
-                                enabledB = handler(FixtureB, FixtureA, this) && enabledB;
+                    // Reverse the order of the reported fixtures. The first fixture is always the one that the
+                    // user subscribed to.
+                    if (FixtureB.OnCollision != null)
+                        foreach (OnCollisionEventHandler handler in FixtureB.OnCollision.GetInvocationList())
+                            enabledB = handler(FixtureB, FixtureA, this) && enabledB;
 
-                        Enabled = enabledA && enabledB;
+                    Enabled = enabledA && enabledB;
 
-                        // BeginContact can also return false and disable the contact
-                        if (enabledA && enabledB && contactManager.BeginContact != null)
-                            Enabled = contactManager.BeginContact(this);
-                    }
-                    else
-                    {
-                        //Report the collision to both participants:
-                        if (FixtureA.OnCollision != null)
-                            foreach (OnCollisionEventHandler handler in FixtureA.OnCollision.GetInvocationList())
-                                Enabled = handler(FixtureA, FixtureB, this);
-
-                        //Reverse the order of the reported fixtures. The first fixture is always the one that the
-                        //user subscribed to.
-                        if (FixtureB.OnCollision != null)
-                            foreach (OnCollisionEventHandler handler in FixtureB.OnCollision.GetInvocationList())
-                                Enabled = handler(FixtureB, FixtureA, this);
-
-                        //BeginContact can also return false and disable the contact
-                        if (contactManager.BeginContact != null)
-                            Enabled = contactManager.BeginContact(this);
-                    }
+                    // BeginContact can also return false and disable the contact
+                    if (enabledA && enabledB && contactManager.BeginContact != null)
+                        Enabled = contactManager.BeginContact(this);
 
                     // If the user disabled the contact (needed to exclude it in TOI solver) at any point by
                     // any of the callbacks, we need to mark it as not touching and call any separation

--- a/Physics2D/Dynamics/Contacts/Contact.cs
+++ b/Physics2D/Dynamics/Contacts/Contact.cs
@@ -348,12 +348,13 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
                 {
                     //Report the separation to both participants:
                     if (FixtureA != null && FixtureA.OnSeparation != null)
-                        FixtureA.OnSeparation(FixtureA, FixtureB);
+                        FixtureA.OnSeparation(FixtureA, FixtureB, this);
 
                     //Reverse the order of the reported fixtures. The first fixture is always the one that the
                     //user subscribed to.
                     if (FixtureB != null && FixtureB.OnSeparation != null)
-                        FixtureB.OnSeparation(FixtureB, FixtureA);
+                        FixtureB.OnSeparation(FixtureB, FixtureA, this);
+
 
                     if (contactManager.EndContact != null)
                         contactManager.EndContact(this);

--- a/Physics2D/Dynamics/Contacts/Contact.cs
+++ b/Physics2D/Dynamics/Contacts/Contact.cs
@@ -329,6 +329,18 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
                         foreach (OnCollisionEventHandler handler in FixtureB.OnCollision.GetInvocationList())
                             enabledB = handler(FixtureB, FixtureA, this) && enabledB;
 
+                    // Report the collision to both bodies:
+                    if (FixtureA.Body != null && FixtureA.Body.onCollisionEventHandler != null)
+                        foreach (OnCollisionEventHandler handler in FixtureA.Body.onCollisionEventHandler.GetInvocationList())
+                            enabledA = handler(FixtureA, FixtureB, this) && enabledA;
+
+                    // Reverse the order of the reported fixtures. The first fixture is always the one that the
+                    // user subscribed to.
+                    if (FixtureB.Body != null && FixtureB.Body.onCollisionEventHandler != null)
+                        foreach (OnCollisionEventHandler handler in FixtureB.Body.onCollisionEventHandler.GetInvocationList())
+                            enabledB = handler(FixtureB, FixtureA, this) && enabledB;
+
+
                     Enabled = enabledA && enabledB;
 
                     // BeginContact can also return false and disable the contact
@@ -354,6 +366,15 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
                     //user subscribed to.
                     if (FixtureB != null && FixtureB.OnSeparation != null)
                         FixtureB.OnSeparation(FixtureB, FixtureA, this);
+                    
+                    //Report the separation to both bodies:
+                    if (FixtureA != null && FixtureA.Body != null && FixtureA.Body.onSeparationEventHandler != null)
+                        FixtureA.Body.onSeparationEventHandler(FixtureA, FixtureB, this);
+
+                    //Reverse the order of the reported fixtures. The first fixture is always the one that the
+                    //user subscribed to.
+                    if (FixtureB != null && FixtureB.Body != null && FixtureB.Body.onSeparationEventHandler != null)
+                        FixtureB.Body.onSeparationEventHandler(FixtureB, FixtureA, this);
 
 
                     if (contactManager.EndContact != null)

--- a/Physics2D/Dynamics/World.cs
+++ b/Physics2D/Dynamics/World.cs
@@ -992,6 +992,10 @@ namespace tainicom.Aether.Physics2D.Dynamics
             }
             body.ContactList = null;
 
+            // remove the attached contact callbacks
+            body.onCollisionEventHandler = null;
+            body.onSeparationEventHandler = null;
+
             // Delete the attached fixtures. This destroys broad-phase proxies.
             for (int i = 0; i < body.FixtureList.Count; i++)
             {

--- a/Physics2D/Dynamics/WorldCallbacks.cs
+++ b/Physics2D/Dynamics/WorldCallbacks.cs
@@ -60,9 +60,9 @@ namespace tainicom.Aether.Physics2D.Dynamics
 
     public delegate bool BeforeCollisionEventHandler(Fixture fixtureA, Fixture fixtureB);
 
-    public delegate bool OnCollisionEventHandler(Fixture fixtureA, Fixture fixtureB, Contact contact);
+    public delegate bool OnCollisionEventHandler(Fixture sender, Fixture other, Contact contact);
 
     public delegate void AfterCollisionEventHandler(Fixture fixtureA, Fixture fixtureB, Contact contact, ContactVelocityConstraint impulse);
 
-    public delegate void OnSeparationEventHandler(Fixture fixtureA, Fixture fixtureB);
+    public delegate void OnSeparationEventHandler(Fixture sender, Fixture other, Contact contact);
 }

--- a/Physics2D/Settings.cs
+++ b/Physics2D/Settings.cs
@@ -39,13 +39,6 @@ namespace tainicom.Aether.Physics2D
         // Common
 
         /// <summary>
-        /// If true, all collision callbacks have to return the same value, and agree
-        /// if there was a collision or not. Swtich this to false to revert to the 
-        /// collision agreement used in FPE 3.3.x
-        /// </summary>
-        public const bool AllCollisionCallbacksAgree = true;
-
-        /// <summary>
         /// Enabling diagnistics causes the engine to gather timing information.
         /// You can see how much time it took to solve the contacts, solve CCD
         /// and update the controllers.

--- a/Samples/Testbed/Tests/CharacterCollisionTest.cs
+++ b/Samples/Testbed/Tests/CharacterCollisionTest.cs
@@ -144,13 +144,13 @@ namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
             _character.SleepingAllowed = false;
         }
 
-        private bool CharacterOnCollision(Fixture fixtureA, Fixture fixtureB, Contact contact)
+        private bool CharacterOnCollision(Fixture sender, Fixture other, Contact contact)
         {
             _collision = true;
             return true;
         }
 
-        private void CharacterOnSeparation(Fixture fixtureA, Fixture fixtureB)
+        private void CharacterOnSeparation(Fixture sender, Fixture other, Contact contact)
         {
             _collision = false;
         }

--- a/Samples/Testbed/Tests/DeletionTest.cs
+++ b/Samples/Testbed/Tests/DeletionTest.cs
@@ -20,14 +20,14 @@ namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
             ground.OnSeparation += OnSeparation;
         }
 
-        private bool OnCollision(Fixture fixtureA, Fixture fixtureB, Contact contact)
+        private bool OnCollision(Fixture sender, Fixture other, Contact contact)
         {
             return true;
         }
 
-        private void OnSeparation(Fixture fixtureA, Fixture fixtureB)
+        private void OnSeparation(Fixture sender, Fixture other, Contact Contact)
         {
-            fixtureB.Body.World.Remove(fixtureB.Body);
+            other.Body.World.Remove(other.Body);
         }
 
         public override void Update(GameSettings settings, GameTime gameTime)

--- a/Samples/Testbed/Tests/LockTest.cs
+++ b/Samples/Testbed/Tests/LockTest.cs
@@ -33,7 +33,7 @@ namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
             //Fixture()
         }
 
-        private bool OnCollision(Fixture fixturea, Fixture fixtureb, Contact manifold)
+        private bool OnCollision(Fixture sender, Fixture other, Contact contact)
         {
             //_rectangle.CreateFixture(_rectangle.Shape); //Calls the constructor in Fixture
             //_rectangle.Remove(_rectangle);


### PR DESCRIPTION
The current implementation will ignore events from fixtures added after subscription to the events and also will not remove the subscription from removed fixtures.
This PR wires the events directly to Fixture.Body.