### PR TITLE
Remove IgnoreCollisionWith

### DIFF
--- a/Physics2D/Dynamics/Body.cs
+++ b/Physics2D/Dynamics/Body.cs
@@ -1168,34 +1168,7 @@ namespace tainicom.Aether.Physics2D.Dynamics
             remove { onSeparationEventHandler -= value; }
         }
         
-        /// <summary>
-        /// Warning: This method applies the value on existing Fixtures. It's not a property of Body.
-        /// </summary>
-        public void IgnoreCollisionWith(Body other)
-        {
-            for (int i = 0; i < FixtureList.Count; i++)
-            {
-                for (int j = 0; j < other.FixtureList.Count; j++)
-                {
-                    FixtureList[i].IgnoreCollisionWith(other.FixtureList[j]);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Warning: This method applies the value on existing Fixtures. It's not a property of Body.
-        /// </summary>
-        public void RestoreCollisionWith(Body other)
-        {
-            for (int i = 0; i < FixtureList.Count; i++)
-            {
-                for (int j = 0; j < other.FixtureList.Count; j++)
-                {
-                    FixtureList[i].RestoreCollisionWith(other.FixtureList[j]);
-                }
-            }
-        }
-
+        
         /// <summary>
         /// Set restitution on all fixtures.
         /// Warning: This method applies the value on existing Fixtures. It's not a property of Body.

--- a/Physics2D/Dynamics/ContactManager.cs
+++ b/Physics2D/Dynamics/ContactManager.cs
@@ -413,10 +413,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
                      Category.None))
                     return false;
 
-                if (fixtureA.IsFixtureIgnored(fixtureB) ||
-                    fixtureB.IsFixtureIgnored(fixtureA))
-                    return false;
-
                 return true;
             }
 
@@ -428,15 +424,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
 
             bool collide = (fixtureA.CollidesWith & fixtureB.CollisionCategories) != 0 &&
                            (fixtureA.CollisionCategories & fixtureB.CollidesWith) != 0;
-
-            if (collide)
-            {
-                if (fixtureA.IsFixtureIgnored(fixtureB) ||
-                    fixtureB.IsFixtureIgnored(fixtureA))
-                {
-                    return false;
-                }
-            }
 
             return collide;
         }

--- a/Physics2D/Dynamics/Fixture.cs
+++ b/Physics2D/Dynamics/Fixture.cs
@@ -55,7 +55,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
         internal Category _collidesWith;
         internal Category _collisionCategories;
         internal short _collisionGroup;
-        internal HashSet<Fixture> _collisionIgnores;
 
         public FixtureProxy[] Proxies { get; private set; }
         public int ProxyCount { get; private set; }
@@ -91,7 +90,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
             _collisionCategories = Settings.DefaultFixtureCollisionCategories;
             _collidesWith = Settings.DefaultFixtureCollidesWith;
             _collisionGroup = 0;
-            _collisionIgnores = new HashSet<Fixture>();
 
             IgnoreCCDWith = Settings.DefaultFixtureIgnoreCCDWith;
 
@@ -241,45 +239,7 @@ namespace tainicom.Aether.Physics2D.Dynamics
             }
         }
         
-
-        /// <summary>
-        /// Restores collisions between this fixture and the provided fixture.
-        /// </summary>
-        /// <param name="fixture">The fixture.</param>
-        public void RestoreCollisionWith(Fixture fixture)
-        {
-            if (_collisionIgnores.Contains(fixture))
-            {
-                _collisionIgnores.Remove(fixture);
-                Refilter();
-            }
-        }
-
-        /// <summary>
-        /// Ignores collisions between this fixture and the provided fixture.
-        /// </summary>
-        /// <param name="fixture">The fixture.</param>
-        public void IgnoreCollisionWith(Fixture fixture)
-        {
-            if (!_collisionIgnores.Contains(fixture))
-            {
-                _collisionIgnores.Add(fixture);
-                Refilter();
-            }
-        }
-
-        /// <summary>
-        /// Determines whether collisions are ignored between this fixture and the provided fixture.
-        /// </summary>
-        /// <param name="fixture">The fixture.</param>
-        /// <returns>
-        /// 	<c>true</c> if the fixture is ignored; otherwise, <c>false</c>.
-        /// </returns>
-        public bool IsFixtureIgnored(Fixture fixture)
-        {
-            return _collisionIgnores.Contains(fixture);
-        }
-
+        
         /// <summary>
         /// Contacts are persistant and will keep being persistant unless they are
         /// flagged for filtering.
@@ -441,10 +401,7 @@ namespace tainicom.Aether.Physics2D.Dynamics
             fixture._collisionCategories = _collisionCategories;
             fixture._collidesWith = _collidesWith;
             fixture.IgnoreCCDWith = IgnoreCCDWith;
-
-            foreach (Fixture ignore in _collisionIgnores)
-                fixture._collisionIgnores.Add(ignore);
-
+            
             body.Add(fixture);
             return fixture;
         }

--- a/Samples/Testbed/Tests/CollisionFilteringTest.cs
+++ b/Samples/Testbed/Tests/CollisionFilteringTest.cs
@@ -31,6 +31,7 @@ using tainicom.Aether.Physics2D.Dynamics;
 using tainicom.Aether.Physics2D.Dynamics.Joints;
 using tainicom.Aether.Physics2D.Samples.Testbed.Framework;
 using Microsoft.Xna.Framework;
+using tainicom.Aether.Physics2D.Dynamics.Contacts;
 
 namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
 {
@@ -54,6 +55,8 @@ namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
         private const Category TriangleMask = Category.All;
         private const Category BoxMask = Category.All ^ TriangleCategory;
         private const Category CircleMask = Category.All;
+
+        Fixture circleFixture3;
 
         private CollisionFilteringTest()
         {
@@ -167,13 +170,21 @@ namespace tainicom.Aether.Physics2D.Samples.Testbed.Tests
                 circleBody3.Position = new Vector2(6.0f, 9.0f);
 
                 //Another large circle. This one uses IgnoreCollisionWith() logic instead of categories.
-                Fixture circleFixture3 = circleBody3.CreateFixture(circle);
+                circleFixture3 = circleBody3.CreateFixture(circle);
                 circleFixture3.CollisionGroup = LargeGroup;
                 circleFixture3.CollisionCategories = CircleCategory;
                 circleFixture3.CollidesWith = CircleMask;
 
-                circleFixture3.IgnoreCollisionWith(circleFixture2);
+                circleFixture3.BeforeCollision = circleFixture3_BeforeCollision;
             }
+        }
+
+        bool circleFixture3_BeforeCollision(Fixture sender, Fixture other)
+        {
+            if (other == circleFixture3)
+                return false;
+
+            return true;
         }
 
         internal static Test Create()


### PR DESCRIPTION
_collisionIgnores is not cleared when a Fixture/Body is removed.
This will require a log(n) operation on all bodies, or storing a ref
/link between the two Fixtures.
In such cases there are callbacks like `Fixture.BeforeCollision`
and `ContactManager.ContactFilter` (broadphase) or  `Fixture.OnCollision`
and `ContactManager.BeginContact` (narrowphase).