### PR TITLE
[Samples] Set _fixedMouseJoint = null when it's removed from the World.

### DIFF
--- a/Samples/NewSamples/ScreenSystem/PhysicsDemoScreen.cs
+++ b/Samples/NewSamples/ScreenSystem/PhysicsDemoScreen.cs
@@ -63,9 +63,14 @@ namespace tainicom.Aether.Physics2D.Samples.ScreenSystem
         public override void LoadContent()
         {
             if (World == null)
+            {
                 World = new World(Vector2.Zero);
+                World.JointRemoved += JointRemoved;
+            }
             else
+            {
                 World.Clear();
+            }
 
             if (DebugView == null)
             {
@@ -84,6 +89,12 @@ namespace tainicom.Aether.Physics2D.Samples.ScreenSystem
                 Camera.ResetCamera();
 
             base.LoadContent();
+        }
+
+        protected virtual void JointRemoved(World sender, Joint joint)
+        {
+            if (_fixedMouseJoint == joint)
+                _fixedMouseJoint = null;
         }
 
         public override void Update(GameTime gameTime, bool otherScreenHasFocus, bool coveredByOtherScreen)

--- a/Samples/Samples/ScreenSystem/PhysicsGameScreen.cs
+++ b/Samples/Samples/ScreenSystem/PhysicsGameScreen.cs
@@ -50,9 +50,14 @@ namespace tainicom.Aether.Physics2D.Samples.ScreenSystem
             base.LoadContent();
 
             if (World == null)
+            {
                 World = new World(Vector2.Zero);
+                World.JointRemoved += JointRemoved;
+            }
             else
+            {
                 World.Clear();
+            }
 
             if (DebugView == null)
             {
@@ -73,6 +78,12 @@ namespace tainicom.Aether.Physics2D.Samples.ScreenSystem
 
             // Loading may take a while... so prevent the game from "catching up" once we finished loading
             ScreenManager.Game.ResetElapsedTime();
+        }
+        
+        protected virtual void JointRemoved(World sender, Joint joint)
+        {
+            if (_fixedMouseJoint == joint)
+                _fixedMouseJoint = null;
         }
 
         public override void Update(GameTime gameTime, bool otherScreenHasFocus, bool coveredByOtherScreen)


### PR DESCRIPTION
This behaviour is the same as TestBed.Test.
Fixes #31
