### PR TITLE
Remove Fixture.IgnoreCCDWith

### DIFF
--- a/Physics2D/Dynamics/Body.cs
+++ b/Physics2D/Dynamics/Body.cs
@@ -1213,21 +1213,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
                 FixtureList[i].CollidesWith = category;
         }
 
-#if USE_IGNORE_CCD_CATEGORIES
-        /// <summary>
-        /// Body objects can define which categories of bodies they wish to ignore CCD with. 
-        /// This allows certain bodies to be configured to ignore CCD with objects that
-        /// aren't a penetration problem due to the way content has been prepared.
-        /// This is compared against the other Body's fixture CollisionCategories within World.SolveTOI().
-        /// Warning: This method applies the value on existing Fixtures. It's not a property of Body.
-        /// </summary>
-        public void SetIgnoreCCDWith(Category category)
-        {
-            for (int i = 0; i < FixtureList.Count; i++)
-                FixtureList[i].IgnoreCCDWith = category;
-        }
-#endif
-
         /// <summary>
         /// Warning: This method applies the value on existing Fixtures. It's not a property of Body.
         /// </summary>

--- a/Physics2D/Dynamics/Fixture.cs
+++ b/Physics2D/Dynamics/Fixture.cs
@@ -58,10 +58,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
         public FixtureProxy[] Proxies { get; private set; }
         public int ProxyCount { get; private set; }
 
-#if USE_IGNORE_CCD_CATEGORIES
-        public Category IgnoreCCDWith;
-#endif
-
         /// <summary>
         /// Fires after two shapes has collided and are solved. This gives you a chance to get the impact force.
         /// </summary>
@@ -91,10 +87,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
             _collisionCategories = Category.Cat1;
             _collidesWith = Category.All;
             _collisionGroup = 0;
-
-#if USE_IGNORE_CCD_CATEGORIES
-            IgnoreCCDWith = Category.None;
-#endif
 
             //Fixture defaults
             Friction = 0.2f;
@@ -394,9 +386,6 @@ namespace tainicom.Aether.Physics2D.Dynamics
             fixture._collisionGroup = _collisionGroup;
             fixture._collisionCategories = _collisionCategories;
             fixture._collidesWith = _collidesWith;
-#if USE_IGNORE_CCD_CATEGORIES
-            fixture.IgnoreCCDWith = IgnoreCCDWith;
-#endif
             
             body.Add(fixture);
             return fixture;

--- a/Physics2D/Dynamics/World.cs
+++ b/Physics2D/Dynamics/World.cs
@@ -34,7 +34,6 @@
 // USE_AWAKE_BODY_SET
 // USE_ISLAND_SET
 // OPTIMIZE_TOI
-// USE_IGNORE_CCD_CATEGORIES
 
 using System;
 using System.Collections.Generic;
@@ -550,13 +549,8 @@ namespace tainicom.Aether.Physics2D.Dynamics
                             continue;
                         }
 
-#if USE_IGNORE_CCD_CATEGORIES
-                        bool collideA = (bA.IsBullet || typeA != BodyType.Dynamic) && ((fA.IgnoreCCDWith & fB.CollisionCategories) == 0) && !bA.IgnoreCCD;
-                        bool collideB = (bB.IsBullet || typeB != BodyType.Dynamic) && ((fB.IgnoreCCDWith & fA.CollisionCategories) == 0) && !bB.IgnoreCCD;
-#else
                         bool collideA = (bA.IsBullet || typeA != BodyType.Dynamic) && !bA.IgnoreCCD;
                         bool collideB = (bB.IsBullet || typeB != BodyType.Dynamic) && !bB.IgnoreCCD;
-#endif
 
                         // Are these two non-bullet dynamic bodies?
                         if (collideA == false && collideB == false)


### PR DESCRIPTION
A) The behaviour of `.IgnoreCCDWith` is not fool proof. If a Body has 2
fixtures with categories Cat8 and Cat9 and a another body ignores only
the Cat9, this might result in those two bodies ovelapping (on the
fixture of Cat9) and an overshoot in next Step.

B) If two bodies are known to not be a penetration problem, then the
existing collision mechanism
(CollisionCategories/CollidesWith/CollisionGroup/etc) should be enough
to disable collision during the broadphase.