### PR TITLE
Optimize SolvePositionConstraints()

### DIFF
--- a/Physics2D/Dynamics/Body.cs
+++ b/Physics2D/Dynamics/Body.cs
@@ -1102,8 +1102,7 @@ namespace tainicom.Aether.Physics2D.Dynamics
 
         internal void SynchronizeFixtures()
         {
-            Transform xf1 = new Transform();
-            xf1.q.Phase = _sweep.A0;
+            Transform xf1 = new Transform(Vector2.Zero, _sweep.A0);
             xf1.p = _sweep.C0 - Complex.Multiply(ref _sweep.LocalCenter, ref xf1.q);
 
             IBroadPhase broadPhase = World.ContactManager.BroadPhase;

--- a/Physics2D/Dynamics/Contacts/ContactSolver.cs
+++ b/Physics2D/Dynamics/Contacts/ContactSolver.cs
@@ -816,16 +816,16 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
                 Vector2 cB = _positions[indexB].c;
                 float aB = _positions[indexB].a;
 
+                Transform xfA = new Transform();
+                Transform xfB = new Transform();
+                xfA.q.Phase = aA;
+                xfB.q.Phase = aB;
+                xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
+                xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
+
                 // Solve normal constraints
                 for (int j = 0; j < pointCount; ++j)
                 {
-                    Transform xfA = new Transform();
-                    Transform xfB = new Transform();
-                    xfA.q.Phase = aA;
-                    xfB.q.Phase = aB;
-                    xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
-                    xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
-
                     Vector2 normal;
                     Vector2 point;
                     float separation;
@@ -906,17 +906,17 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
 
                 Vector2 cB = _positions[indexB].c;
                 float aB = _positions[indexB].a;
+                
+                Transform xfA = new Transform();
+                Transform xfB = new Transform();
+                xfA.q.Phase = aA;
+                xfB.q.Phase = aB;
+                xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
+                xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
 
                 // Solve normal constraints
                 for (int j = 0; j < pointCount; ++j)
                 {
-                    Transform xfA = new Transform();
-                    Transform xfB = new Transform();
-                    xfA.q.Phase = aA;
-                    xfB.q.Phase = aB;
-                    xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
-                    xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
-
                     Vector2 normal;
                     Vector2 point;
                     float separation;

--- a/Physics2D/Dynamics/Contacts/ContactSolver.cs
+++ b/Physics2D/Dynamics/Contacts/ContactSolver.cs
@@ -234,10 +234,8 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
 
                 Debug.Assert(manifold.PointCount > 0);
 
-                Transform xfA = new Transform();
-                Transform xfB = new Transform();
-                xfA.q.Phase = aA;
-                xfB.q.Phase = aB;
+                Transform xfA = new Transform(Vector2.Zero, aA);
+                Transform xfB = new Transform(Vector2.Zero, aB);
                 xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
                 xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
 
@@ -816,10 +814,8 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
                 Vector2 cB = _positions[indexB].c;
                 float aB = _positions[indexB].a;
 
-                Transform xfA = new Transform();
-                Transform xfB = new Transform();
-                xfA.q.Phase = aA;
-                xfB.q.Phase = aB;
+                Transform xfA = new Transform(Vector2.Zero, aA);
+                Transform xfB = new Transform(Vector2.Zero, aB);
                 xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
                 xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
 
@@ -906,11 +902,9 @@ namespace tainicom.Aether.Physics2D.Dynamics.Contacts
 
                 Vector2 cB = _positions[indexB].c;
                 float aB = _positions[indexB].a;
-                
-                Transform xfA = new Transform();
-                Transform xfB = new Transform();
-                xfA.q.Phase = aA;
-                xfB.q.Phase = aB;
+
+                Transform xfA = new Transform(Vector2.Zero, aA);
+                Transform xfB = new Transform(Vector2.Zero, aB);
                 xfA.p = cA - Complex.Multiply(ref localCenterA, ref xfA.q);
                 xfB.p = cB - Complex.Multiply(ref localCenterB, ref xfB.q);
 


### PR DESCRIPTION
Optimize SolvePositionConstraints() by calculating Transforms once for all contact points.
About +2% performance In Multithread1Test.
