### PR TITLE
Order Proxy pairs by ProxyIdB first. Reduce Cache Misses.

### DIFF
--- a/Physics2D/Collision/DynamicTreeBroadPhase.cs
+++ b/Physics2D/Collision/DynamicTreeBroadPhase.cs
@@ -40,17 +40,17 @@ namespace tainicom.Aether.Physics2D.Collision
 
         public int CompareTo(Pair other)
         {
-            if (ProxyIdA < other.ProxyIdA)
+            if (ProxyIdB < other.ProxyIdB)
             {
                 return -1;
             }
-            if (ProxyIdA == other.ProxyIdA)
+            if (ProxyIdB == other.ProxyIdB)
             {
-                if (ProxyIdB < other.ProxyIdB)
+                if (ProxyIdA < other.ProxyIdA)
                 {
                     return -1;
                 }
-                if (ProxyIdB == other.ProxyIdB)
+                if (ProxyIdA == other.ProxyIdA)
                 {
                     return 0;
                 }


### PR DESCRIPTION
Order Pairs in BroadPhase by ProxyB first, ProxyA second.

This improves the probability of BodyB.ContactList being
in the cache later in ContactManager.AddPair().

A noticeable improvement on AddPair test. Tumbler test is not affected.