### PR TITLE
Fix TreeNode.Height initial value (Box2D)

### DIFF
--- a/Physics2D/Collision/DynamicTree.cs
+++ b/Physics2D/Collision/DynamicTree.cs
@@ -46,8 +46,10 @@ namespace tainicom.Aether.Physics2D.Collision
         internal int Child1;
         internal int Child2;
 
+        // leaf = 0, free node = -1
         internal int Height;
         internal int ParentOrNext;
+
         internal T UserData;
 
         internal bool IsLeaf()
@@ -92,11 +94,11 @@ namespace tainicom.Aether.Physics2D.Collision
             {
                 _nodes[i] = new TreeNode<T>();
                 _nodes[i].ParentOrNext = i + 1;
-                _nodes[i].Height = 1;
+                _nodes[i].Height = -1;
             }
             _nodes[_nodeCapacity - 1] = new TreeNode<T>();
             _nodes[_nodeCapacity - 1].ParentOrNext = NullNode;
-            _nodes[_nodeCapacity - 1].Height = 1;
+            _nodes[_nodeCapacity - 1].Height = -1;
             _freeList = 0;
         }
 


### PR DESCRIPTION
Box2D ref:

https://github.com/erincatto/Box2D/blob/12e732706a69146866b8e8ecb80d608cf56f92a5/Box2D/Collision/b2DynamicTree.h#L49

https://github.com/erincatto/Box2D/blob/12e732706a69146866b8e8ecb80d608cf56f92a5/Box2D/Collision/b2DynamicTree.cpp#L32-L38

AllocateNode() is correct:

https://github.com/tainicom/Aether.Physics2D/blob/69ad2ed4addd9a9ac8713ee1441f8da9f94d9094/Physics2D/Collision/DynamicTree.cs#L476-L484