### PR TITLE
Fix revolutions formula

### DIFF
--- a/Physics2D/Dynamics/Body.cs
+++ b/Physics2D/Dynamics/Body.cs
@@ -100,7 +100,7 @@ namespace tainicom.Aether.Physics2D.Dynamics
         /// <value>The revolutions.</value>
         public float Revolutions
         {
-            get { return Rotation / (float)Math.PI; }
+            get { return Rotation / (2 * (float)Math.PI); }
         }
 
         /// <summary>


### PR DESCRIPTION
The `Revolutions` property was calculating the total number of half revolutions (`Rotation / Math.PI`) a body has made instead of the number of full revolutions (`Rotation / (2 * Math.PI)`).